### PR TITLE
Feature request: change sms messaage format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "app/language_pack"]
 	path = app/language_pack
-	url = https://github.com/telegram-sms/language_pack.git
+	url = https://github.com/malash/telegram-sms-language_pack.git
 [submodule "app/src/main/java/com/github/sumimakito/awesomeqrcode"]
 	path = app/src/main/java/com/github/sumimakito/awesomeqrcode
 	url = https://github.com/telegram-sms/AwesomeQrRenderer.git

--- a/app/src/main/java/com/qwe7002/telegram_sms/sms_receiver.java
+++ b/app/src/main/java/com/qwe7002/telegram_sms/sms_receiver.java
@@ -127,19 +127,18 @@ public class sms_receiver extends BroadcastReceiver {
         final request_message request_body = new request_message();
         request_body.chat_id = chat_id;
 
-        String message_body_html = message_body;
-        final String message_head = "[" + dual_sim + context.getString(R.string.receive_sms_head) + "]" + "\n" + context.getString(R.string.from) + message_address + "\n" + context.getString(R.string.content);
+        String message_body_html = message_body
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("&", "&amp;");
+        final String message_head = context.getString(R.string.sim_slot) + dual_sim + "\n" + context.getString(R.string.from) + message_address;
         String raw_request_body_text = message_head + message_body;
         boolean is_verification_code = false;
         if (sharedPreferences.getBoolean("verification_code", false) && !is_trusted_phone) {
             if (message_body.length() <= 140) {
                 String verification = code_aux_lib.find(message_body);
                 if (verification != null) {
-                    request_body.parse_mode = "html";
-                    message_body_html = message_body
-                            .replace("<", "&lt;")
-                            .replace(">", "&gt;")
-                            .replace("&", "&amp;")
+                    message_body_html = message_body_html
                             .replace(verification, "<code>" + verification + "</code>");
                     is_verification_code = true;
                 }
@@ -147,7 +146,8 @@ public class sms_receiver extends BroadcastReceiver {
                 log_func.write_log(context, "SMS exceeds 140 characters, no verification code is recognized.");
             }
         }
-        request_body.text = message_head + message_body_html;
+        request_body.parse_mode = "html";
+        request_body.text = "<b>" + message_body_html + "</b>" + "\n" + "\n" + message_head;
         if (is_trusted_phone) {
             log_func.write_log(context, "SMS from trusted mobile phone detected");
             String message_command = message_body.toLowerCase().replace("_", "").replace("-", "");


### PR DESCRIPTION
This PR:

1. Change the order of SMS content and attributions. Show the content at first brings a better notification experience.
2. Add `<b></b>` for SMS content.

<img width="589" alt="image" src="https://user-images.githubusercontent.com/1812118/200243296-5ded81b6-bacc-413b-bb63-b5096a320194.png">


This PR is only for preview and not fully tested. You can try it [here](https://github.com/malash/telegram-sms/releases/tag/v2022.11.07). If this feature was accepted, I would be willing to complete the rest works.